### PR TITLE
GameMenu rewiring, FileDialog tweaks

### DIFF
--- a/C7/C7Game.tscn
+++ b/C7/C7Game.tscn
@@ -332,4 +332,6 @@ visible = false
 [connection signal="DiplomacySelection" from="CanvasLayer/PopupOverlay" to="." method="OnDiplomacySelected"]
 [connection signal="HidePopup" from="CanvasLayer/PopupOverlay" to="CanvasLayer/PopupOverlay" method="OnHidePopup"]
 [connection signal="Quit" from="CanvasLayer/PopupOverlay" to="." method="OnQuitTheGame"]
-[connection signal="Retire" from="CanvasLayer/PopupOverlay" to="." method="_on_QuitButton_pressed"]
+[connection signal="Retire" from="CanvasLayer/PopupOverlay" to="." method="OnRetire"]
+[connection signal="SaveGame" from="CanvasLayer/PopupOverlay" to="." method="OnSaveGame"]
+[connection signal="LoadGame" from="CanvasLayer/PopupOverlay" to="." method="OnLoadGame"]

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -535,7 +535,7 @@ public partial class Game : Node {
 		popupOverlay.OnHidePopup(); // hide game menu
 
 		// FileDialog is a Window, not a Control, so we have the popup overlay present a blank control
-		popupOverlay.ShowDialog(new Control());
+		popupOverlay.ShowBlank();
 
 		// TODO: this should go to our own saves directory.
 		FileDialog.SetDirectoryForSaving(@"Conquests/Saves");
@@ -548,8 +548,9 @@ public partial class Game : Node {
 		popupOverlay.OnHidePopup(); // hide game menu
 
 		// FileDialog is a Window, not a Control, so we have the popup overlay present a blank control
-		popupOverlay.ShowDialog(new Control());
+		popupOverlay.ShowBlank();
 
+		// TODO: this should go to our own saves directory.
 		FileDialog.SetDirectoryForLoading(@"Conquests/Saves");
 
 		// TODO: sound -- see MainMenu.PlayButtonPressedSound();

--- a/C7/Game.cs
+++ b/C7/Game.cs
@@ -125,6 +125,7 @@ public partial class Game : Node {
 	Stopwatch loadTimer = new Stopwatch();
 
 	GlobalSingleton Global;
+	Civ3FileDialog FileDialog;
 
 	public Player controller; // Player that's controlling the UI.
 
@@ -165,6 +166,10 @@ public partial class Game : Node {
 	// that gives an error if we fail to load for some reason.
 	public override async void _Ready() {
 		Global = GetNode<GlobalSingleton>("/root/GlobalSingleton");
+
+		FileDialog = GetNode<Civ3FileDialog>("%LoadDialog");
+		FileDialog.Canceled += OnResolved;
+		FileDialog.FileSelected += path => OnResolved();
 
 		try {
 			await InitializeGame();
@@ -521,12 +526,38 @@ public partial class Game : Node {
 		EmitSignal(SignalName.PlayerTurnEnd);
 	}
 
-	public void _on_QuitButton_pressed() {
-		// This apparently exits the whole program
-		// GetTree().Quit();
-
-		// ChangeSceneToFile deletes the current scene and frees its memory, so this is quitting to main menu
+	public void OnRetire() {
+		// Quit to main menu, freeing previous scene data
 		GetTree().ChangeSceneToFile("res://UIElements/MainMenu/main_menu.tscn");
+	}
+
+	public void OnSaveGame() {
+		popupOverlay.OnHidePopup(); // hide game menu
+
+		// FileDialog is a Window, not a Control, so we have the popup overlay present a blank control
+		popupOverlay.ShowDialog(new Control());
+
+		// TODO: this should go to our own saves directory.
+		FileDialog.SetDirectoryForSaving(@"Conquests/Saves");
+
+		// TODO: sound -- see MainMenu.PlayButtonPressedSound();
+		FileDialog.Popup();
+	}
+
+	public void OnLoadGame() {
+		popupOverlay.OnHidePopup(); // hide game menu
+
+		// FileDialog is a Window, not a Control, so we have the popup overlay present a blank control
+		popupOverlay.ShowDialog(new Control());
+
+		FileDialog.SetDirectoryForLoading(@"Conquests/Saves");
+
+		// TODO: sound -- see MainMenu.PlayButtonPressedSound();
+		FileDialog.Popup();
+	}
+
+	public void OnResolved() {
+		popupOverlay.OnHidePopup();
 	}
 
 	public void _on_Zoom_value_changed(float value) {

--- a/C7/UIElements/Popups/GameMenu.cs
+++ b/C7/UIElements/Popups/GameMenu.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Godot;
 using Serilog;
 
@@ -16,59 +17,56 @@ public partial class GameMenu : Popup {
 
 		AddHeader("Main Menu", 10);
 
-		// TODO: enable buttons as the features are implemented
-		AddButton("Map", 60, map);
-		AddButton("Load Game", 85, load);
-		//AddButton("New Game (Ctrl-Shift-Q)", 110, newGame);
-		//AddButton("Preferences (Ctrl-P)", 135, preferences);
-		AddButton("Retire", 110, retire);
-		AddButton("Save Game", 135, save);
-		AddButton("Quit Game (ESC)", 160, quit);
+		// Note: Enable buttons as the features are implemented
 
+		Tuple<string, Action>[] buttons = [
+			new("Map", ShowMap),
+			new("Load Game", Load),
+			// new("New Game (Ctrl-Shift-Q)", NewGame),
+			// TODO: Quick Start?
+			// new("Preferences (Ctrl-P)", OpenPreferences),
+			new("Retire", Retire),
+			new("Save Game", Save),
+			new("Quit Game (ESC)", Quit)
+		];
+
+		int verticalOffset = 60;
+		int rowHeight = 25;
+
+		var indexedButtons = buttons.Select((x, i) =>
+			new { Label = x.Item1, Func = x.Item2, Idx = i });
+
+		foreach (var button in indexedButtons) {
+			AddButton(button.Label, verticalOffset + button.Idx * rowHeight, button.Func);
+		}
 	}
 
-	private void save() {
-		var loadDialog = GetNode<Civ3FileDialog>("../%LoadDialog");
-		// TODO: this should go to our own saves directory.
-		loadDialog.SetDirectoryForSaving(@"Conquests/Saves");
+	private void Load() {
+		GetParent().EmitSignal(PopupOverlay.SignalName.LoadGame);
+	}
 
-		// TODO: The main menu does sound playing but we don't know our path in
-		// the scene, which makes this hard.
-		// PlayButtonPressedSound();
+	private void Save() {
+		GetParent().EmitSignal(PopupOverlay.SignalName.SaveGame);
+	}
+
+
+	private void ShowMap() { // i.e., Cancel: return from menu to game
 		GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
-
-		loadDialog.Popup();
 	}
 
-	private void preferences() {
-		throw new NotImplementedException();
-	}
-
-	private void newGame() {
-		throw new NotImplementedException();
-	}
-
-	private void load() {
-		var loadDialog = GetNode<Civ3FileDialog>("../%LoadDialog");
-		loadDialog.SetDirectoryForLoading(@"Conquests/Saves");
-
-		// TODO: The main menu does sound playing but we don't know our path in
-		// the scene, which makes this hard.
-		// PlayButtonPressedSound();
-		GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
-
-		loadDialog.Popup();
-	}
-
-	private void quit() {
-		GetParent().EmitSignal(PopupOverlay.SignalName.Quit);
-	}
-
-	private void retire() {
+	private void Retire() {
 		GetParent().EmitSignal(PopupOverlay.SignalName.Retire);
 	}
 
-	private void map() {
-		GetParent().EmitSignal(PopupOverlay.SignalName.HidePopup);
+	private void Quit() {
+		GetParent().EmitSignal(PopupOverlay.SignalName.Quit);
+	}
+
+	private void NewGame() {
+		// TODO: Wire to a NewGame scene
+	}
+
+	private void OpenPreferences() {
+		// TODO: Preferences management - disable animation, etc.
 	}
 }

--- a/C7/UIElements/Popups/Popup.cs
+++ b/C7/UIElements/Popups/Popup.cs
@@ -47,7 +47,10 @@ public partial class Popup : TextureRect {
 		};
 		button.SetPosition(new Vector2(HORIZONTAL_POSITION, verticalPosition));
 		AddChild(button);
-		button.Pressed += action;
+		button.Pressed += () => {
+			action();
+			ReleaseFocus();
+		};
 	}
 
 	protected void AddHeader(string text, int vOffset) {

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -8,12 +8,20 @@ public partial class PopupOverlay : HBoxContainer {
 
 	private ILogger log = LogManager.ForContext<PopupOverlay>();
 
-	[Signal] public delegate void QuitEventHandler();
-	[Signal] public delegate void RetireEventHandler();
-	[Signal] public delegate void BuildCityEventHandler(string name);
-	[Signal] public delegate void DiplomacySelectionEventHandler(ParameterWrapper<ID> opponentPlayer);
+	// Meta
 	[Signal] public delegate void HidePopupEventHandler();
 	[Signal] public delegate void ClickEventHandler();
+
+	// Game events
+	[Signal] public delegate void BuildCityEventHandler(string name);
+	[Signal] public delegate void DiplomacySelectionEventHandler(ParameterWrapper<ID> opponentPlayer);
+
+	// Menu events
+	[Signal] public delegate void SaveGameEventHandler();
+	[Signal] public delegate void LoadGameEventHandler();
+	[Signal] public delegate void RetireEventHandler();
+	[Signal] public delegate void QuitEventHandler();
+
 
 	Control currentChild = null;
 
@@ -76,6 +84,13 @@ public partial class PopupOverlay : HBoxContainer {
 		if (wav != null) {
 			PlaySound(wav);
 		}
+	}
+
+	public void ShowDialog(Control child) {
+		AddChild(child);
+		currentChild = child;
+		Isolate();
+		Show();
 	}
 
 	/// <summary>
@@ -142,7 +157,7 @@ public partial class PopupOverlay : HBoxContainer {
 		}
 
 		if (@event is InputEventMouseButton ev) {
-			// Catch right clicks over UI elements to stop awkward TileInfo renders 
+			// Catch right clicks over UI elements to stop awkward TileInfo renders
 			if (ev.ButtonIndex == MouseButton.Right) {
 				if (IsOverUI()) {
 					AcceptEvent();

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -65,9 +65,6 @@ public partial class PopupOverlay : HBoxContainer {
 		OffsetLeft = child.margins.left;
 		OffsetRight = child.margins.right;
 
-		AddChild(child);
-		currentChild = child;
-
 		var soundFile = category switch {
 			PopupCategory.Advisor => "Sounds/PopupAdvisor.wav",
 			PopupCategory.Console => "Sounds/PopupConsole.wav",
@@ -77,16 +74,18 @@ public partial class PopupOverlay : HBoxContainer {
 
 		var wav = soundFile == null ? null : Util.LoadCiv3WAVFromDisk(soundFile);
 
-		Isolate();
-
-		Show();
+		ShowChild(child);
 
 		if (wav != null) {
 			PlaySound(wav);
 		}
 	}
 
-	public void ShowDialog(Control child) {
+	public void ShowBlank() {
+		ShowChild(new Control());
+	}
+
+	private void ShowChild(Control child) {
 		AddChild(child);
 		currentChild = child;
 		Isolate();

--- a/C7/UIElements/UpperLeftNav/AdvisorButton.cs
+++ b/C7/UIElements/UpperLeftNav/AdvisorButton.cs
@@ -7,4 +7,9 @@ public partial class AdvisorButton : Civ3TextureButton {
 	public override void _Ready() {
 		TextureLoader.SetButtonTextures(this, "upper_left_navigation.advisor");
 	}
+
+	public override void _Pressed() {
+		base._Pressed();
+		ReleaseFocus();
+	}
 }

--- a/C7/UIElements/UpperLeftNav/CivilopediaButton.cs
+++ b/C7/UIElements/UpperLeftNav/CivilopediaButton.cs
@@ -9,4 +9,9 @@ public partial class CivilopediaButton : Civ3TextureButton {
 		ImageTexture menuTexture = TextureLoader.Load("upper_left_navigation.civilopedia");
 		this.TextureNormal = menuTexture;
 	}
+
+	public override void _Pressed() {
+		base._Pressed();
+		ReleaseFocus();
+	}
 }

--- a/C7/UIElements/UpperLeftNav/MenuButton.cs
+++ b/C7/UIElements/UpperLeftNav/MenuButton.cs
@@ -14,6 +14,7 @@ public partial class MenuButton : Civ3TextureButton {
 
 	public override void _Pressed() {
 		popupOverlay.ShowPopup(new GameMenu(), PopupOverlay.PopupCategory.Info);
+		ReleaseFocus();
 	}
 
 }

--- a/C7/UIElements/civ3_file_dialog.tscn
+++ b/C7/UIElements/civ3_file_dialog.tscn
@@ -4,6 +4,6 @@
 
 [node name="LoadDialog" type="FileDialog"]
 initial_position = 1
-size = Vector2i(312, 450)
+size = Vector2i(512, 450)
 visible = true
 script = ExtResource("1_mb1lm")


### PR DESCRIPTION
- Rewire GameMenu, use signals more consistently
- Fix FileDialog UI event bugs, including #963
- Fix focus bugs that result in Space key triggering buttons when wanting to end turn / skip unit after clicking menu
- Widen FileDialog a bit, so it's less annoying to use