### PR TITLE
Tech box UI fix

### DIFF
--- a/C7/UIElements/Advisors/ScienceAdvisor.cs
+++ b/C7/UIElements/Advisors/ScienceAdvisor.cs
@@ -107,6 +107,13 @@ public partial class ScienceAdvisor : Control {
 	}
 
 	void DrawTechTree(string eraName, Player player, List<Tech> allTechs, HashSet<Tech> availableTechsToResearch) {
+		// clear all tech-box items so we don't draw new ones over the old ones
+		foreach (TechBox tb in techBoxes) {
+			background.RemoveChild(tb);
+			tb.QueueFree();
+		}
+		techBoxes.Clear();
+
 		HashSet<ID> knownTechs = player.knownTechs;
 		previousEra.Show();
 		nextEra.Show();


### PR DESCRIPTION
Remove the old tech box items, before we add new ones as the new ones are being drawn over the existing ones without the old ones ever being deleted.

(before, courtesy of @WildWeazel )
<img width="736" height="483" alt="image" src="https://github.com/user-attachments/assets/f10fc29e-3075-495e-83b3-6bedb9b69d3a" />
