### PR TITLE
Extract recursive mouse filter into NodeExtensions; fix popup event leak

### DIFF
--- a/C7/UIElements/NodeExtensions.cs
+++ b/C7/UIElements/NodeExtensions.cs
@@ -1,0 +1,17 @@
+using Godot;
+
+public static class NodeExtensions {
+	/// <summary>
+	/// Recursively set MouseFilter on the node and all of its descendants.
+	/// </summary>
+	/// <param name="node">Root of the subtree to update.</param>
+	/// <param name="filter">MouseFilterEnum to apply to every Control in the subtree.</param>
+	public static void SetMouseFilterRecursive(this Node node, Control.MouseFilterEnum filter) {
+		foreach (var child in node.GetChildren()) {
+			child.SetMouseFilterRecursive(filter);
+		}
+		if (node is Control control) {
+			control.MouseFilter = filter;
+		}
+	}
+}

--- a/C7/UIElements/NodeExtensions.cs.uid
+++ b/C7/UIElements/NodeExtensions.cs.uid
@@ -1,0 +1,1 @@
+uid://rq5sbnpwm54lq

--- a/C7/UIElements/Popups/PopupOverlay.cs
+++ b/C7/UIElements/Popups/PopupOverlay.cs
@@ -104,7 +104,7 @@ public partial class PopupOverlay : HBoxContainer {
 		control.ProcessMode = ProcessModeEnum.Disabled;
 
 		// 3. Ignore all mouse input on UI elements
-		SetMouseFilter(control, MouseFilterEnum.Ignore);
+		control.SetMouseFilterRecursive(MouseFilterEnum.Ignore);
 	}
 
 	/// <summary>
@@ -112,24 +112,11 @@ public partial class PopupOverlay : HBoxContainer {
 	/// Inverse of `Isolate(..)`.
 	/// </summary>
 	private void Reconnect() {
-		// 1. Let events propagate past the overlay
-		control.MouseFilter = MouseFilterEnum.Pass;
+		// 1. Let UI elements catch mouse inputs again, propagating events past the overlay
+		control.SetMouseFilterRecursive(MouseFilterEnum.Pass);
 
-		// 2. Let UI elements catch mouse inputs again
-		SetMouseFilter(control, MouseFilterEnum.Pass);
-
-		// 3. Restart the world: let UI elements run normal
+		// 2. Restart the world: let UI elements run normal
 		control.ProcessMode = ProcessModeEnum.Inherit;
-	}
-
-	/// Recursively set MouseFilter on node children and their children, etc.
-	private static void SetMouseFilter(Node n, MouseFilterEnum filter) {
-		foreach (var child in n?.GetChildren() ?? []) {
-			SetMouseFilter(child, filter);
-		}
-		if (n is Control control) {
-			control.MouseFilter = filter;
-		}
 	}
 
 	public override void _GuiInput(InputEvent @event) {

--- a/C7/UIElements/Popups/TileInfoPopup.cs
+++ b/C7/UIElements/Popups/TileInfoPopup.cs
@@ -24,6 +24,8 @@ public partial class TileInfoPopup : Popup {
 
 	private List<Label> _labels = new();
 
+	private PopupOverlay _overlay;
+
 	public TileInfoPopup(Game game, Tile tile, Vector2 position, float zoom) {
 		_game = game;
 		_tile = tile;
@@ -148,7 +150,15 @@ public partial class TileInfoPopup : Popup {
 		});
 
 		var overlay = GetParent<PopupOverlay>();
+		_overlay = overlay;
 		overlay.Click += Close; // a click outside the box means close
+	}
+
+	public override void _ExitTree() {
+		if (_overlay != null && IsInstanceValid(_overlay)) {
+			_overlay.Click -= Close;
+		}
+		base._ExitTree();
 	}
 
 	public override void _GuiInput(InputEvent @event) {


### PR DESCRIPTION
Closes #452.

## Summary

**1. Make modal mouse-filter blocking reusable (#452)**
`PopupOverlay` had a private static `SetMouseFilter` that recursed through a subtree setting the Godot `MouseFilter`. This moves it to a public extension method, `NodeExtensions.SetMouseFilterRecursive(this Node, Control.MouseFilterEnum)`, so any code can generically block/restore input to a subtree. `PopupOverlay.Isolate()`/`Reconnect()` now call it; the private helper is removed (along with a redundant `control.MouseFilter` assignment that the recursion already handled).

**2. Fix a popup signal-handler leak (found while testing #452)**
`TileInfoPopup` subscribes to `PopupOverlay.Click` to dismiss on an outside click (`overlay.Click += Close`) but never unsubscribes. Because the closed popup is only removed from the tree (not freed) and the delegate keeps it alive, the stale handler persists. Concretely: after opening any tile-info popup once, clicking outside a later modal (e.g. the Escape quit menu) would invoke the stale handler, which calls `HideTileInfo()` → `OnHidePopup()`, closing the modal that should have stayed open. This unsubscribes in `_ExitTree` (guarded by `IsInstanceValid` for app teardown), so the tile-info dismiss behavior remains but can no longer affect other popups.

## Testing

- `dotnet build C7/C7.sln`: 0 errors.
- `dotnet test C7/C7.sln` with `CIV3_HOME` set: 67 passed, 0 failed, 0 skipped.
- Manual, in-game (Godot 4.4.1):
  - Modal popups (Escape quit menu, build-city, advisors) still block background input while open and restore it on close.
  - Tile-info popup still dismisses on an outside click.
  - Regression for the leak: open a tile-info popup, dismiss it, then open the Escape quit menu — clicking outside now correctly leaves the menu open.